### PR TITLE
Fix wrong array accesses

### DIFF
--- a/classify.cpp
+++ b/classify.cpp
@@ -17,7 +17,7 @@ int classify::straight_flush() const {
      int test=1; //test while loop condition
      int k=0;    //variable use for scanning elements of arrays
      while(test!=0) {
-	  if(store_rank[k]==((store_rank[k+1])-1) && k<hand-1) {
+	  if(k<hand-1 && store_rank[k]==((store_rank[k+1])-1)) {
                if(store_suit[k]==store_suit[k+1]) {
                     ++k;
                }
@@ -56,7 +56,7 @@ int classify::straight() const {
      int test=1;
      int k=0;
      while(test!=0) {
-         if(store_rank[k]==((store_rank[k+1])-1) && k < hand-1) {
+         if(k < hand-1 && store_rank[k]==((store_rank[k+1])-1)) {
              ++k;       //continue loop
          }
 	 else if(k==hand-1) {
@@ -130,7 +130,7 @@ int classify::one_pair() const {
 }
 
 int classify::plain() const {
-     for(int k=0; k<hand; k++) {
+     for(int k=0; k<hand-1; k++) {
 	     if(store_rank[k]==store_rank[k+1] || flush()==1) {
 	          return 0;  //no plain found
 	     }


### PR DESCRIPTION
When compiling the code with `g++ -o poker.bin -I./include poker.cpp cards.cpp classify.cpp -O3` (note the `-O3` flag) (also works with other optimizations such as `-O2`) the program always returns 0 encounters of `PLAIN`, `STRAIGHT` and `STRAIGHT_FLUSH`. This is because of illegal array indices being accessed.